### PR TITLE
Include sys/types.h for off_t

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1,6 +1,7 @@
 #include "common.h"
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include <Rinternals.h>
 


### PR DESCRIPTION
On R built with Intel compiler suite, install of tiff package fails as off_t is not defined. Include <sys/types.h> so that it is available.
