### PR TITLE
Add support for tiled images, reading directory only, reading specific images

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^src/local323.zip$
+^src/lib/
+^src/include/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll
+
+src/win32/
+src/win64/
+src/libtiff-current-win.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ src/*.o
 src/*.so
 src/*.dll
 
-src/win32/
-src/win64/
-src/libtiff-current-win.tar.gz
+src/include/
+src/lib/
+src/local323.zip

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: tiff
-Version: 0.1-5
+Version: 0.1-6
 Title: Read and write TIFF images
 Author: Simon Urbanek <Simon.Urbanek@r-project.org>
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,4 @@ Description: This package provides an easy and simple way to read, write
 License: GPL-2 | GPL-3
 SystemRequirements: tiff and jpeg libraries
 URL: http://www.rforge.net/tiff/
-Suggests: testthat
+Suggests: testthat (>= 2.0.0), rprojroot

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,14 @@
 Package: tiff
 Version: 0.1-6
 Title: Read and write TIFF images
-Author: Simon Urbanek <Simon.Urbanek@r-project.org>
-Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>
+Authors@R: as.person(c(
+    "Simon Urbanek <Simon.Urbanek@r-project.org> [aut, cre]", 
+    "Kent Johnson <kent.johnson@perkinelmer.com> [aut]"
+  ))
 Depends: R (>= 2.9.0)
-Description: This package provides an easy and simple way to read, write and display bitmap images stored in the TIFF format. It can read and write both files and in-memory raw vectors.
+Description: This package provides an easy and simple way to read, write 
+    and display bitmap images stored in the TIFF format. 
+    It can read and write both files and in-memory raw vectors.
 License: GPL-2 | GPL-3
 SystemRequirements: tiff and jpeg libraries
 URL: http://www.rforge.net/tiff/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,3 +12,4 @@ Description: This package provides an easy and simple way to read, write
 License: GPL-2 | GPL-3
 SystemRequirements: tiff and jpeg libraries
 URL: http://www.rforge.net/tiff/
+Suggests: testthat

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 NEWS/Changelog
 
+0.1-6
+    o   Add readTIFFDirectory() function to read image tags without 
+        reading the actual image.
+        
 0.1-5	2013-09-03
     o	bugfix: output of readTIFF(..., as.is=TRUE) with integer
 	values was shifted by one (i.e., stored integer value x

--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,25 @@
 NEWS/Changelog
 
 0.1-6
-    o   Add readTIFFDirectory() function to read image tags without 
-        reading the actual image.
-        
     o   Add limited support for tiled images. Supports 8-, 16- and 32-bit
         integer and float images with spp=1 or 3. No support for indexed,
         color map, as.is, or planar format color.
+        
+    o   Add readTIFFDirectory() function to read image tags without 
+        reading the actual image.
+
+    o   Add the ability to read (or get info on) selected images by passing
+        a vector in the `all` parameter.
+        
+    o   Add width, length, x.position, y.position, and, if available,
+        rows.per.strip, tile.width, tile.length to the directory
+        info returned when `info=TRUE` (and by readTIFFDirectory).
+
+    o   Update to libtiff 4.0.6 from the Rtools site.
+    
+    o   Stop with an error if `as.is=TRUE` is used with a float image.
+
+    o   Fixed documentation typos.
         
 0.1-5	2013-09-03
     o	bugfix: output of readTIFF(..., as.is=TRUE) with integer

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ NEWS/Changelog
     o   Add readTIFFDirectory() function to read image tags without 
         reading the actual image.
         
+    o   Add limited support for tiled images. Supports 8-, 16- and 32-bit
+        integer and float images with spp=1 or 3. No support for indexed,
+        color map, as.is, or planar format color.
+        
 0.1-5	2013-09-03
     o	bugfix: output of readTIFF(..., as.is=TRUE) with integer
 	values was shifted by one (i.e., stored integer value x

--- a/R/read.R
+++ b/R/read.R
@@ -1,9 +1,11 @@
 readTIFF <- function(source, native=FALSE, all=FALSE, convert=FALSE, info=FALSE, indexed=FALSE, as.is=FALSE)
-  .Call("read_tiff", if (is.raw(source)) source else path.expand(source), native, all, convert, info, indexed, as.is, PACKAGE="tiff")
+  .Call("read_tiff", 
+        if (is.raw(source)) source else path.expand(source), 
+        native, all, convert, info, indexed, as.is, PACKAGE="tiff")
 
 readTIFFDirectory <- function(source, all=FALSE) {
   raw <- .Call("read_tiff_directory",
         if (is.raw(source)) source else path.expand(source), all,
         PACKAGE="tiff")
-  if (all) Map(attributes, raw) else attributes(raw)
+  if (!identical(all, FALSE)) Map(attributes, raw) else attributes(raw)
 }

--- a/R/read.R
+++ b/R/read.R
@@ -1,2 +1,9 @@
 readTIFF <- function(source, native=FALSE, all=FALSE, convert=FALSE, info=FALSE, indexed=FALSE, as.is=FALSE)
   .Call("read_tiff", if (is.raw(source)) source else path.expand(source), native, all, convert, info, indexed, as.is, PACKAGE="tiff")
+
+readTIFFDirectory <- function(source, all=FALSE) {
+  raw <- .Call("read_tiff_directory",
+        if (is.raw(source)) source else path.expand(source), all,
+        PACKAGE="tiff")
+  if (all) Map(attributes, raw) else attributes(raw)
+}

--- a/R/read.R
+++ b/R/read.R
@@ -1,6 +1,6 @@
 readTIFF <- function(source, native=FALSE, all=FALSE, convert=FALSE, info=FALSE, indexed=FALSE, as.is=FALSE)
-  .Call("read_tiff", 
-        if (is.raw(source)) source else path.expand(source), 
+  .Call("read_tiff",
+        if (is.raw(source)) source else path.expand(source),
         native, all, convert, info, indexed, as.is, PACKAGE="tiff")
 
 readTIFFDirectory <- function(source, all=FALSE) {

--- a/configure.win
+++ b/configure.win
@@ -3,24 +3,24 @@
 echo "  checking TIFF headers and libraries"
 allok=yes
 
-if [ ! -e src/win32/libz.a ]; then
-    if [ ! -e src/libtiff-current-win.tar.gz ]; then
+if [ ! -e src/lib/i386/libz.a ]; then
+    if [ ! -e src/local323.zip ]; then
 	echo "  cannot find current TIFF files"
 	echo "  attempting to download them"
-	echo 'download.file("http://www.rforge.net/tiff/files/libtiff-current-win.tar.gz","src/libtiff-current-win.tar.gz",mode="wb",quiet=TRUE)'|${R_HOME}/bin/R --vanilla --slave
+	echo 'download.file("https://www.stats.ox.ac.uk/pub/Rtools/goodies/multilib/local323.zip","src/local323.zip",mode="wb",quiet=TRUE)'|${R_HOME}/bin/R --vanilla --slave
     fi
-    if [ ! -e src/libtiff-current-win.tar.gz ]; then
+    if [ ! -e src/local323.zip ]; then
 	allok=no
     else
 	echo "  unpacking current TIFF"
-	tar fxz src/libtiff-current-win.tar.gz -C src
-        if [ ! -e src/win32/libz.a ]; then
+	unzip src/local323.zip -d src
+        if [ ! -e src/lib/i386/libz.a ]; then
 	    allok=no
 	fi
     fi
 fi
 
-if [ ! -e src/win32/libz.a ]; then
+if [ ! -e src/lib/i386/libz.a ]; then
     allok=no
 fi
 
@@ -28,11 +28,11 @@ if [ ${allok} != yes ]; then
     echo ""
     echo " *** ERROR: unable to find TIFF files"
     echo ""
-    echo " They must be either in src/win32 or in a tar-ball"
-    echo " src/libtiff-current-win.tar.gz"
+    echo " They must be either in src/lib/i386 or in a zip file"
+    echo " src/local323.zip"
     echo ""
-    echo " You can get the latest binary tar ball from"
-    echo " http://www.rforge.net/tiff/files/"
+    echo " You can get the latest binary zip from"
+    echo " https://www.stats.ox.ac.uk/pub/Rtools/goodies/multilib"
     echo ""
     exit 1
 fi

--- a/man/readTIFF.Rd
+++ b/man/readTIFF.Rd
@@ -16,8 +16,10 @@ readTIFF(source, native = FALSE, all = FALSE, convert = FALSE,
   \item{native}{determines the image representation - if \code{FALSE}
   (the default) then the result is an array, if \code{TRUE} then the
   result is a native raster representation (suitable for plotting).}
-\item{all}{TIFF files can contain more than one image, if \code{all =
-    TRUE} then all images are returned in a list, otherwise only the first
+\item{all}{TIFF files can contain more than one image. If \code{all =
+    TRUE} then all images are returned in a list
+    of images. If \code{all} is a vector, it gives the (1-based) 
+    indices of images to return. Otherwise only the first
   image is returned.}
 \item{convert}{first convert the image into 8-bit RGBA samples and then
   to an array, see below for details.}
@@ -29,7 +31,7 @@ readTIFF(source, native = FALSE, all = FALSE, convert = FALSE,
   \code{"color.map"} attribute. This flag cannot be combined with
   \code{convert} or \code{native} and has no effect on images that are
   not indexed.}
-\item{as.is}{attempt to return original values without re-scaling
+\item{as.is}{attempt to return original integer values without re-scaling
   where possible}
 }
 \value{
@@ -42,8 +44,9 @@ point sample storage which are unscaled reals, and for indexed and
 returned instead. The latter cannot be easily computed on but is the
 most efficient way to draw using \code{rasterImage}.
 
-If \code{all} is \code{TRUE} then the result is a list of the above with
-one or more elements..
+If \code{all} is \code{TRUE} or a vector of image indices,
+then the result is a list of the above with
+zero or more elements..
 }
 \details{
 Most common files decompress into RGB (3 channels), RGBA (4 channels),

--- a/man/readTIFF.Rd
+++ b/man/readTIFF.Rd
@@ -17,7 +17,7 @@ readTIFF(source, native = FALSE, all = FALSE, convert = FALSE,
   (the default) then the result is an array, if \code{TRUE} then the
   result is a native raster representation (suitable for plotting).}
 \item{all}{TIFF files can contain more than one image, if \code{all =
-    TRUE} then all images are returenin a list, otherwsie only the first
+    TRUE} then all images are returned in a list, otherwise only the first
   image is returned.}
 \item{convert}{first convert the image into 8-bit RGBA samples and then
   to an array, see below for details.}

--- a/man/readTIFF.Rd
+++ b/man/readTIFF.Rd
@@ -68,8 +68,9 @@ direct acccess as it is intended mainly for viewing and not computation.
 }
 %\references{
 %}
-%\author{
-%}
+\author{
+Simon Urbanek
+}
 \note{
   Some non-standard formats such as 12-bit TIFFs are partially supported
   (there is no standard for packing order for TIFFs beoynd 8-bit so we

--- a/man/readTIFFDirectory.Rd
+++ b/man/readTIFFDirectory.Rd
@@ -1,0 +1,34 @@
+\name{readTIFFDirectory}
+\alias{readTIFFDirectory}
+\title{
+Read information from an image stored in the TIFF format
+}
+\description{
+Reads informational tags from a TIFF image file/content into a list.
+}
+\usage{
+readTIFFDirectory(source, all = FALSE)
+}
+\arguments{
+  \item{source}{Either name of the file to read from or a raw vector
+  representing the TIFF file content.}
+\item{all}{TIFF files can contain more than one image. If \code{all =
+    TRUE} then information about all images is returned in a list
+    of lists, otherwise only information about the first
+  image is returned.}
+}
+\value{
+A list of
+informational values from the first image directory of \code{source}.
+
+If \code{all} is \code{TRUE} then the result is a list of the above with
+one or more elements..
+}
+\seealso{
+\code{\link{readTIFF}}
+}
+\examples{
+# read directory information from a sample file (R logo)
+readTIFFDirectory(system.file("img", "Rlogo.tiff", package="tiff"))
+}
+\keyword{IO}

--- a/man/readTIFFDirectory.Rd
+++ b/man/readTIFFDirectory.Rd
@@ -14,14 +14,16 @@ readTIFFDirectory(source, all = FALSE)
   representing the TIFF file content.}
 \item{all}{TIFF files can contain more than one image. If \code{all =
     TRUE} then information about all images is returned in a list
-    of lists, otherwise only information about the first
+    of lists. If \code{all} is a vector, it gives the (1-based) 
+    indices of images to return. Otherwise only information about the first
   image is returned.}
 }
 \value{
 A list of
 informational values from the first image directory of \code{source}.
 
-If \code{all} is \code{TRUE} then the result is a list of the above with
+If \code{all} is \code{TRUE} or a vector of image indices,
+then the result is a list of the above with
 one or more elements..
 }
 \seealso{

--- a/man/readTIFFDirectory.Rd
+++ b/man/readTIFFDirectory.Rd
@@ -26,6 +26,10 @@ If \code{all} is \code{TRUE} or a vector of image indices,
 then the result is a list of the above with
 one or more elements..
 }
+\author{
+Simon Urbanek
+Kent Johnson
+}
 \seealso{
 \code{\link{readTIFF}}
 }

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,8 @@
 ## detect 64-bit Windows
 ifeq "$(WIN)" "64"
-PKG_CFLAGS=-Iwin64
-PKG_LIBS=-Lwin64 -ltiff -ljpeg -lz
+PKG_CFLAGS=-Iinclude
+PKG_LIBS=-Llib/x64 -ltiff -ljpeg -lz
 else
-PKG_CFLAGS=-Iwin32
-PKG_LIBS=-Lwin32 -ltiff -ljpeg -lz
+PKG_CFLAGS=-Iinclude
+PKG_LIBS=-Llib/i386 -ltiff -ljpeg -lz
 endif

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 ## detect 64-bit Windows
-ifeq ($(strip $(shell $(R_HOME)/bin/R --slave -e 'cat(.Machine$$sizeof.pointer)')),8)
+ifeq "$(WIN)" "64"
 PKG_CFLAGS=-Iwin64
 PKG_LIBS=-Lwin64 -ltiff -ljpeg -lz
 else

--- a/src/common.c
+++ b/src/common.c
@@ -1,6 +1,7 @@
 #include "common.h"
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include <Rinternals.h>
 

--- a/src/read.c
+++ b/src/read.c
@@ -205,15 +205,18 @@ SEXP read_tiff_directory(SEXP sFn, SEXP sAll) {
             }
         }
         
+        /* Read the TIFF directory as attributes of res */
     	PROTECT(res = allocVector(VECSXP, 0));
 	TIFF_add_info(tiff, res);
 	UNPROTECT(1);
 	
+	/* if (sAll is FALSE) */
 	if (isLogical(sAll) && (asInteger(sAll)==0)) {
 	    TIFFClose(tiff);
 	    return res;
 	}
 	
+	/* Build a linked list of results */
 	n_img++;
 	if (multi_res == R_NilValue) {
 	    multi_tail = multi_res = CONS(res, R_NilValue);

--- a/src/read.c
+++ b/src/read.c
@@ -21,6 +21,10 @@ static void TIFF_add_info(TIFF *tiff, SEXP res) {
     float f;
     char *c = 0;
 
+    if (TIFFGetField(tiff, TIFFTAG_IMAGEWIDTH, &i32))
+	setAttr(res, "width", ScalarInteger(i32));
+    if (TIFFGetField(tiff, TIFFTAG_IMAGELENGTH, &i32))
+	setAttr(res, "length", ScalarInteger(i32));
     if (TIFFGetField(tiff, TIFFTAG_IMAGEDEPTH, &i32))
 	setAttr(res, "depth", ScalarInteger(i32));
     if (TIFFGetField(tiff, TIFFTAG_BITSPERSAMPLE, &i16))

--- a/src/read.c
+++ b/src/read.c
@@ -273,7 +273,9 @@ SEXP read_tiff(SEXP sFn, SEXP sNative, SEXP sAll, SEXP sConvert, SEXP sInfo, SEX
 	    else if (colormap[1]) out_spp = 2;
 	}
 #if TIFF_DEBUG
-	Rprintf("image %d x %d x %d, tiles %d x %d, bps = %d, spp = %d (output %d), config = %d, colormap = %s\n", imageWidth, imageLength, imageDepth, tileWidth, tileLength, bps, spp, out_spp, config, colormap[0] ? "yes" : "no");
+	Rprintf("image %d x %d x %d, tiles %d x %d, bps = %d, spp = %d (output %d), config = %d, colormap = %s,\n", 
+            imageWidth, imageLength, imageDepth, tileWidth, tileLength, bps, spp, out_spp, config, colormap[0] ? "yes" : "no");
+        Rprintf("      float = %d\n", is_float);
 #endif
 	
 	if (native || convert) {
@@ -355,11 +357,16 @@ SEXP read_tiff(SEXP sFn, SEXP sNative, SEXP sAll, SEXP sConvert, SEXP sInfo, SEX
 	    if (!TIFFReadDirectory(tiff))
 		break;
 	    continue;
-	}
+	} /* end native || convert */
 	
 	if (bps != 8 && bps != 16 && bps != 32 && ( bps != 12 || spp != 1 )) {
 	    TIFFClose(tiff);
 	    Rf_error("image has %d bits/sample which is unsupported in direct mode - use native=TRUE or convert=TRUE", bps);
+	}
+
+	if (original && is_float) {
+	    TIFFClose(tiff);
+	    Rf_error("as.is=TRUE is not supported for floating point images");
 	}
 
 	if (sformat == SAMPLEFORMAT_INT && !original)

--- a/src/read.c
+++ b/src/read.c
@@ -6,15 +6,15 @@
 
 #include <Rinternals.h>
 
-/* avoid protection issues with setAttrib where new symbols may trigger GC probelms */
+/* avoid protection issues with setAttrib where new symbols may trigger GC problems */
 static void setAttr(SEXP x, const char *name, SEXP val) {
     PROTECT(val);
     setAttrib(x, Rf_install(name), val);
     UNPROTECT(1);
 }
 
-/* add information attributes accorsing to the TIGG tags.
-   Only a somewhat randome set (albeit mostly baseline) is supported */
+/* add information attributes according to the TIFF tags.
+   Only a somewhat random set (albeit mostly baseline) is supported */
 static void TIFF_add_info(TIFF *tiff, SEXP res) {
     uint32 i32;
     uint16 i16;
@@ -82,6 +82,10 @@ static void TIFF_add_info(TIFF *tiff, SEXP res) {
 	setAttr(res, "x.resolution", ScalarReal(f));
     if (TIFFGetField(tiff, TIFFTAG_YRESOLUTION, &f))
 	setAttr(res, "y.resolution", ScalarReal(f));
+    if (TIFFGetField(tiff, TIFFTAG_XPOSITION, &f))
+	setAttr(res, "x.position", ScalarReal(f));
+    if (TIFFGetField(tiff, TIFFTAG_YPOSITION, &f))
+	setAttr(res, "y.position", ScalarReal(f));
     if (TIFFGetField(tiff, TIFFTAG_RESOLUTIONUNIT, &i16)) {
 	const char *name = "unknown";
 	switch (i16) {

--- a/src/read.c
+++ b/src/read.c
@@ -60,6 +60,16 @@ static void TIFF_add_info(TIFF *tiff, SEXP res) {
 	    setAttr(res, "planar.config", mkString(uv));
 	}
     }
+    
+    if (TIFFGetField(tiff, TIFFTAG_ROWSPERSTRIP, &i32))
+        setAttr(res, "rows.per.strip", ScalarInteger(i32));
+    
+    if (TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &i32)) {
+        setAttr(res, "tile.width", ScalarInteger(i32));
+        TIFFGetField(tiff, TIFFTAG_TILELENGTH, &i32);
+        setAttr(res, "tile.length", ScalarInteger(i32));
+    }
+    
     if (TIFFGetField(tiff, TIFFTAG_COMPRESSION, &i16)) {
 	char uv[24];
 	const char *name = 0;

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(tiff)
+
+test_check("tiff")

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -11,6 +11,7 @@ check_attributes <- function(attrs) {
         samples.per.pixel = 4L, 
         sample.format = "uint", 
         planar.config = "contiguous", 
+        rows.per.strip = 76,
         compression = "LZW", 
         resolution.unit = "inch", 
         orientation = "top.left", 
@@ -66,4 +67,62 @@ test_that("readTIFFDirectory works", {
     
     attrs <- readTIFFDirectory(path, all=2)
     expect_equal(length(attrs), 0) # attrs is an empty now, there is no image 2
+})
+
+test_that("Reading tiles works", {
+    # Some tests that only work on @PKI-Kent's dev box :-/
+    root = rprojroot::find_package_root_file()
+    data_folder = file.path(root, '..', 'tiffData')
+    skip_if_not(file.exists(data_folder))
+    
+    # These files all contain multiple images including tiled images
+    ## 32-bit float ##
+    path = file.path(data_folder, 'Float32_Tiled.tif')
+    info = readTIFFDirectory(path, all=TRUE)
+    expect_equal(length(info), 5)
+    
+    expect_equivalent(
+            info[[1]][c('width','length', 
+                        'bits.per.sample', 'samples.per.pixel', 
+                        'tile.width')],
+            c(3728, 2784, 32, 1, 512))
+    expect_equal(info[[1]][['sample.format']], 'float')
+    
+    # Check reading multiple images
+    images = readTIFF(path, all=c(1, 3))
+    expect_equal(length(images), 2)
+    expect_equal(dim(images[[1]]), c(2784, 3728))
+    expect_equal(dim(images[[2]]), c(348, 466, 3)) # RGB thumbnail
+
+    ## 8-bit RGB ##
+    path = file.path(data_folder, 'RGB_Tiled.tif')
+    info = readTIFFDirectory(path, all=TRUE)
+    expect_equal(length(info), 6)
+    
+    # The third image is the smallest tiled image; check it
+    expect_equivalent(
+            info[[3]][c('width','length', 'bits.per.sample', 'samples.per.pixel', 'tile.width')],
+            c(2784, 2080, 8, 3, 512))
+    expect_equal(info[[3]][['sample.format']], 'uint')
+    images = readTIFF(path, all=3)
+    
+    # all != FALSE returns a list
+    expect_equal(length(images), 1)
+    expect_equal(dim(images[[1]]), c(2080, 2784, 3))
+    
+    ## 8-bit grayscale ##
+    path = file.path(data_folder, 'UInt8_Tiled.tif')
+    info = readTIFFDirectory(path, all=TRUE)
+    expect_equal(length(info), 9)
+    
+    expect_equivalent(
+            info[[3]][c('width','length', 
+                        'bits.per.sample', 'samples.per.pixel', 
+                        'tile.width')],
+            c(2784, 2080, 8, 1, 512))
+    expect_equal(info[[3]][['sample.format']], 'uint')
+    
+    images = readTIFF(path, all=3)
+    expect_equal(length(images), 1)
+    expect_equal(dim(images[[1]]), c(2080, 2784))
 })

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -1,0 +1,45 @@
+library(testthat)
+
+# Smoke tests
+
+# Check the attributes read from Rlogo.tiff
+check_attributes <- function(attrs) {
+    expected = list(
+        bits.per.sample = 8L, 
+        samples.per.pixel = 4L, 
+        sample.format = "uint", 
+        planar.config = "contiguous", 
+        compression = "LZW", 
+        resolution.unit = "inch", 
+        orientation = "top.left", 
+        color.space = "RGB")
+
+    expected_double = list(
+        x.resolution = 300, 
+        y.resolution = 300)    
+    
+    for (n in names(expected))
+        expect_equal(attrs[[n]], expected[[n]], info=n)
+    for (n in names(expected_double))
+        expect_equal(attrs[[n]], expected_double[[n]], tolerance=0.001, info=n)
+}
+
+test_that("readTIFF works", {
+    # Don't duplicate the examples...
+    img <- readTIFF(system.file("img", "Rlogo.tiff", package="tiff"), info=TRUE)
+
+    expect_equal(dim(img), c(76, 100, 4))
+    
+    attrs = attributes(img)
+    check_attributes(attrs)
+})
+
+test_that("readTIFFDirectory works", {
+    path = system.file("img", "Rlogo.tiff", package="tiff")
+    attrs <- readTIFFDirectory(path)
+    check_attributes(attrs)
+    
+    attrs <- readTIFFDirectory(path, all=TRUE)
+    expect_equal(length(attrs), 1) # attrs is a list of lists now
+    check_attributes(attrs[[1]])
+})

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -71,8 +71,8 @@ test_that("readTIFFDirectory works", {
 
 test_that("Reading tiles works", {
     # Some tests that only work on @PKI-Kent's dev box :-/
-    root = rprojroot::find_package_root_file()
-    data_folder = file.path(root, '..', 'tiffData')
+    root = rprojroot::find_testthat_root_file()
+    data_folder = file.path(root, '..', '..', '..', 'tiffData')
     skip_if_not(file.exists(data_folder))
     
     # These files all contain multiple images including tiled images

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -28,12 +28,27 @@ check_attributes <- function(attrs) {
 
 test_that("readTIFF works", {
     # Don't duplicate the examples...
-    img <- readTIFF(system.file("img", "Rlogo.tiff", package="tiff"), info=TRUE)
+    path = system.file("img", "Rlogo.tiff", package="tiff")
+    img <- readTIFF(path, info=TRUE)
 
     expect_equal(dim(img), c(76, 100, 4))
-    
     attrs = attributes(img)
     check_attributes(attrs)
+    
+    img <- readTIFF(path, info=TRUE, all=TRUE)
+    expect_equal(length(img), 1)
+    expect_equal(dim(img[[1]]), c(76, 100, 4))
+    attrs = attributes(img[[1]])
+    check_attributes(attrs)
+    
+    img <- readTIFF(path, info=TRUE, all=1)
+    expect_equal(length(img), 1)
+    expect_equal(dim(img[[1]]), c(76, 100, 4))
+    attrs = attributes(img[[1]])
+    check_attributes(attrs)
+    
+    img <- readTIFF(path, info=TRUE, all=2)
+    expect_equal(length(img), 0)
 })
 
 test_that("readTIFFDirectory works", {
@@ -44,4 +59,11 @@ test_that("readTIFFDirectory works", {
     attrs <- readTIFFDirectory(path, all=TRUE)
     expect_equal(length(attrs), 1) # attrs is a list of lists now
     check_attributes(attrs[[1]])
+    
+    attrs <- readTIFFDirectory(path, all=1)
+    expect_equal(length(attrs), 1) # attrs is a list of lists now
+    check_attributes(attrs[[1]])
+    
+    attrs <- readTIFFDirectory(path, all=2)
+    expect_equal(length(attrs), 0) # attrs is an empty now, there is no image 2
 })

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -5,6 +5,8 @@ library(testthat)
 # Check the attributes read from Rlogo.tiff
 check_attributes <- function(attrs) {
     expected = list(
+        width = 100,
+        length = 76,
         bits.per.sample = 8L, 
         samples.per.pixel = 4L, 
         sample.format = "uint", 

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -4,23 +4,23 @@ library(testthat)
 
 # Check the attributes read from Rlogo.tiff
 check_attributes <- function(attrs) {
-    expected = list(
+    expected <- list(
         width = 100,
         length = 76,
-        bits.per.sample = 8L, 
-        samples.per.pixel = 4L, 
-        sample.format = "uint", 
-        planar.config = "contiguous", 
+        bits.per.sample = 8L,
+        samples.per.pixel = 4L,
+        sample.format = "uint",
+        planar.config = "contiguous",
         rows.per.strip = 76,
-        compression = "LZW", 
-        resolution.unit = "inch", 
-        orientation = "top.left", 
+        compression = "LZW",
+        resolution.unit = "inch",
+        orientation = "top.left",
         color.space = "RGB")
 
-    expected_double = list(
-        x.resolution = 300, 
-        y.resolution = 300)    
-    
+    expected_double <- list(
+        x.resolution = 300,
+        y.resolution = 300)
+
     for (n in names(expected))
         expect_equal(attrs[[n]], expected[[n]], info=n)
     for (n in names(expected_double))
@@ -29,100 +29,102 @@ check_attributes <- function(attrs) {
 
 test_that("readTIFF works", {
     # Don't duplicate the examples...
-    path = system.file("img", "Rlogo.tiff", package="tiff")
+    path <- system.file("img", "Rlogo.tiff", package="tiff")
     img <- readTIFF(path, info=TRUE)
 
     expect_equal(dim(img), c(76, 100, 4))
-    attrs = attributes(img)
+    attrs <- attributes(img)
     check_attributes(attrs)
-    
+
     img <- readTIFF(path, info=TRUE, all=TRUE)
     expect_equal(length(img), 1)
     expect_equal(dim(img[[1]]), c(76, 100, 4))
-    attrs = attributes(img[[1]])
+    attrs <- attributes(img[[1]])
     check_attributes(attrs)
-    
+
     img <- readTIFF(path, info=TRUE, all=1)
     expect_equal(length(img), 1)
     expect_equal(dim(img[[1]]), c(76, 100, 4))
-    attrs = attributes(img[[1]])
+    attrs <- attributes(img[[1]])
     check_attributes(attrs)
-    
+
     img <- readTIFF(path, info=TRUE, all=2)
     expect_equal(length(img), 0)
 })
 
 test_that("readTIFFDirectory works", {
-    path = system.file("img", "Rlogo.tiff", package="tiff")
+    path <- system.file("img", "Rlogo.tiff", package="tiff")
     attrs <- readTIFFDirectory(path)
     check_attributes(attrs)
-    
+
     attrs <- readTIFFDirectory(path, all=TRUE)
     expect_equal(length(attrs), 1) # attrs is a list of lists now
     check_attributes(attrs[[1]])
-    
+
     attrs <- readTIFFDirectory(path, all=1)
     expect_equal(length(attrs), 1) # attrs is a list of lists now
     check_attributes(attrs[[1]])
-    
+
     attrs <- readTIFFDirectory(path, all=2)
     expect_equal(length(attrs), 0) # attrs is an empty now, there is no image 2
 })
 
 test_that("Reading tiles works", {
     # Some tests that only work on @PKI-Kent's dev box :-/
-    root = rprojroot::find_testthat_root_file()
-    data_folder = file.path(root, '..', '..', '..', 'tiffData')
+    root <- rprojroot::find_testthat_root_file()
+    data_folder <- file.path(root, '..', '..', '..', 'tiffData')
     skip_if_not(file.exists(data_folder))
-    
+
     # These files all contain multiple images including tiled images
     ## 32-bit float ##
-    path = file.path(data_folder, 'Float32_Tiled.tif')
-    info = readTIFFDirectory(path, all=TRUE)
+    path <- file.path(data_folder, 'Float32_Tiled.tif')
+    info <- readTIFFDirectory(path, all=TRUE)
     expect_equal(length(info), 5)
-    
+
     expect_equivalent(
-            info[[1]][c('width','length', 
-                        'bits.per.sample', 'samples.per.pixel', 
+            info[[1]][c('width', 'length',
+                        'bits.per.sample', 'samples.per.pixel',
                         'tile.width')],
             c(3728, 2784, 32, 1, 512))
     expect_equal(info[[1]][['sample.format']], 'float')
-    
+
     # Check reading multiple images
-    images = readTIFF(path, all=c(1, 3))
+    images <- readTIFF(path, all=c(1, 3))
     expect_equal(length(images), 2)
     expect_equal(dim(images[[1]]), c(2784, 3728))
     expect_equal(dim(images[[2]]), c(348, 466, 3)) # RGB thumbnail
 
     ## 8-bit RGB ##
-    path = file.path(data_folder, 'RGB_Tiled.tif')
-    info = readTIFFDirectory(path, all=TRUE)
+    path <- file.path(data_folder, 'RGB_Tiled.tif')
+    info <- readTIFFDirectory(path, all=TRUE)
     expect_equal(length(info), 6)
-    
+
     # The third image is the smallest tiled image; check it
     expect_equivalent(
-            info[[3]][c('width','length', 'bits.per.sample', 'samples.per.pixel', 'tile.width')],
+            info[[3]][c('width', 'length', 
+                        'bits.per.sample', 'samples.per.pixel', 
+                        'tile.width')],
             c(2784, 2080, 8, 3, 512))
     expect_equal(info[[3]][['sample.format']], 'uint')
-    images = readTIFF(path, all=3)
-    
+    images <- readTIFF(path, all=3)
+
     # all != FALSE returns a list
     expect_equal(length(images), 1)
     expect_equal(dim(images[[1]]), c(2080, 2784, 3))
-    
+
     ## 8-bit grayscale ##
-    path = file.path(data_folder, 'UInt8_Tiled.tif')
-    info = readTIFFDirectory(path, all=TRUE)
+    path <- file.path(data_folder, 'UInt8_Tiled.tif')
+    info <- readTIFFDirectory(path, all=TRUE)
     expect_equal(length(info), 9)
-    
+
     expect_equivalent(
-            info[[3]][c('width','length', 
-                        'bits.per.sample', 'samples.per.pixel', 
+            info[[3]][c('width', 'length',
+                        'bits.per.sample', 'samples.per.pixel',
                         'tile.width')],
             c(2784, 2080, 8, 1, 512))
     expect_equal(info[[3]][['sample.format']], 'uint')
-    
-    images = readTIFF(path, all=3)
+
+    images <- readTIFF(path, all=3)
     expect_equal(length(images), 1)
     expect_equal(dim(images[[1]]), c(2080, 2784))
 })

--- a/tiff.Rproj
+++ b/tiff.Rproj
@@ -5,7 +5,7 @@ SaveWorkspace: Default
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
-UseSpacesForTab: No
+UseSpacesForTab: Yes
 NumSpacesForTab: 8
 Encoding: UTF-8
 

--- a/tiff.Rproj
+++ b/tiff.Rproj
@@ -1,0 +1,16 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: No
+NumSpacesForTab: 8
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
-   Add limited support for tiled images (#4). Supports 8-, 16- and 32-bit
    integer and float images with spp=1 or 3. No support for indexed,
    color map, as.is, or planar format color.
    
-   Add `readTIFFDirectory()` function to read image tags without 
    reading the actual image.

-   Add the ability to read (or get info on) selected images by passing
    a vector in the `all` parameter.
    
-   Add width, length, x.position, y.position, and, if available,
    rows.per.strip, tile.width, tile.length to the directory
    info returned when `info=TRUE` (and by `readTIFFDirectory`).

-   Update to libtiff 4.0.6 from the Rtools site.

-   Stop with an error if `as.is=TRUE` is used with a float image.

-   Fixed documentation typos.
