### PR TITLE
Update linking on Windows to support latest Rtools43

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,4 +1,5 @@
-PKG_LIBS = -ltiff -ljpeg -lz -lzstd -lwebp -llzma 
+LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+PKG_LIBS = -ltiff -ljpeg -lz -lzstd -lwebp $(LIBSHARPYUV) -llzma
 
 all: clean 
 


### PR DESCRIPTION
This change to linking is to support current version of Rtools43, where webp ships with separate sharpyuv. The earlier version of webp included sharpyuv, hence the conditioning.