### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,4 +1,9 @@
-PKG_LIBS = -ltiff -ljpeg -lz -lzstd -lwebp -llzma 
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+   LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+   PKG_LIBS = -ltiff -ljpeg -lz -lzstd -lwebp $(LIBSHARPYUV) -llzma
+else
+   PKG_LIBS = $(shell pkg-config --libs libtiff-4)
+endif
 
 all: clean 
 


### PR DESCRIPTION
This will get the libraries to link on Windows from pkg-config, when available. Also it fixes linking for Rtools43 versions that didn't have pkg-config, yet.